### PR TITLE
Fix auto complete description

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -33,7 +33,7 @@ func getCommand() *model.Command {
 		DisplayName:      "To Do Bot",
 		Description:      "Interact with your to do list.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: add, list",
+		AutoCompleteDesc: "Available commands: add, list, pop",
 		AutoCompleteHint: "[command]",
 	}
 }


### PR DESCRIPTION
The auto complete description did not have pop command. 

<img width="444" alt="Screenshot 2019-12-18 at 10 28 10 PM" src="https://user-images.githubusercontent.com/37879062/71106821-f8958f80-21e5-11ea-9803-30b1191896b5.png">

This PR will add the pop command in autocomplete description. 
