### PR TITLE
command - /todo  returns the list of todos

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -62,7 +62,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	switch command {
 	case "add":
 		handler = p.runAddCommand
-	case "list":
+	case "list", "":
 		handler = p.runListCommand
 	case "pop":
 		handler = p.runPopCommand

--- a/server/command.go
+++ b/server/command.go
@@ -49,31 +49,30 @@ func getCommandResponse(responseType, text string) *model.CommandResponse {
 
 // ExecuteCommand executes a given command and returns a command response.
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	stringArgs := strings.Split(args.Command, " ")
-
-	if len(stringArgs) < 2 {
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getHelp()), nil
-	}
-
-	command := stringArgs[1]
+	stringArgs := strings.Split(strings.TrimSpace(args.Command), " ")
+	lengthOfArgs := len(stringArgs)
+	restOfArgs := []string{}
 
 	var handler func([]string, *model.CommandArgs) (*model.CommandResponse, bool, error)
-
-	switch command {
-	case "add":
-		handler = p.runAddCommand
-	case "list", "":
+	if lengthOfArgs == 1 {
 		handler = p.runListCommand
-	case "pop":
-		handler = p.runPopCommand
+	} else {
+		command := stringArgs[1]
+		if lengthOfArgs > 2 {
+			restOfArgs = stringArgs[2:]
+		}
+		switch command {
+		case "add":
+			handler = p.runAddCommand
+		case "list":
+			handler = p.runListCommand
+		case "pop":
+			handler = p.runPopCommand
+		default:
+			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getHelp()), nil
+		}
 	}
-
-	if handler == nil {
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getHelp()), nil
-	}
-
-	resp, isUserError, err := handler(stringArgs[2:], args)
-
+	resp, isUserError, err := handler(restOfArgs, args)
 	if err != nil {
 		if isUserError {
 			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("__Error: %s__\n\nRun `/todo help` for usage instructions.", err.Error())), nil
@@ -124,7 +123,6 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (*model
 	if err != nil {
 		return nil, false, err
 	}
-
 	p.sendRefreshEvent(extra.UserId)
 
 	responseMessage := "To Do List:\n\n"


### PR DESCRIPTION
#### Summary
This pull request sets `/todo` to return the list of todos as default, it used to return a help text earlier. 

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/8
![issue_8_todo](https://user-images.githubusercontent.com/1695906/72676801-65d66200-3abd-11ea-9c05-059a26c0a21e.gif)


