### PR TITLE
[GH-41] Fix text overflow in the side bar

### DIFF
--- a/webapp/src/components/sidebar_right/todo_issues.jsx
+++ b/webapp/src/components/sidebar_right/todo_issues.jsx
@@ -142,6 +142,7 @@ const getStyle = makeStyleFromTheme((theme) => {
         },
         message: {
             width: '100%',
+            overflowWrap: 'break-word',
         },
     };
 });


### PR DESCRIPTION
**Summary**
This PR makes sure that, if a word overflows it's container, it will break properly.
- the browser support for `overflow-wrap: break-word` is very good.

**Ticket link**
Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/41

![Screenshot from 2020-03-26 20-09-05](https://user-images.githubusercontent.com/24561400/77687050-2d13a700-6f9e-11ea-8cc9-03914cfb434e.png)
