### PR TITLE
[GH43] Fix 'When no SiteURL is set in config, the basePath is not properly set'

### DIFF
--- a/webapp/src/actions.js
+++ b/webapp/src/actions.js
@@ -33,7 +33,7 @@ export function setShowRHSAction(showRHSPluginAction) {
 export const getPluginServerRoute = (state) => {
     const config = getConfig(state);
 
-    let basePath = '/';
+    let basePath = '';
     if (config && config.SiteURL) {
         basePath = new URL(config.SiteURL).pathname;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix 'When no SiteURL is set in config, the basePath is not properly set'

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/43
