### PR TITLE
[GH-34] Fix list realtime

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -85,7 +85,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	var handler func([]string, *model.CommandArgs) (bool, error)
 	if lengthOfArgs == 1 {
 		handler = p.runListCommand
-		p.trackCommand(args.UserId, "")
+		go p.trackCommand(args.UserId, "")
 	} else {
 		command := stringArgs[1]
 		if lengthOfArgs > 2 {
@@ -104,14 +104,14 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			handler = p.runSettingsCommand
 		default:
 			if command == "help" {
-				p.trackCommand(args.UserId, command)
+				go p.trackCommand(args.UserId, command)
 			} else {
-				p.trackCommand(args.UserId, "not found")
+				go p.trackCommand(args.UserId, "not found")
 			}
 			p.postCommandResponse(args, getHelp())
 			return &model.CommandResponse{}, nil
 		}
-		p.trackCommand(args.UserId, command)
+		go p.trackCommand(args.UserId, command)
 	}
 	isUserError, err := handler(restOfArgs, args)
 	if err != nil {
@@ -153,7 +153,7 @@ func (p *Plugin) runSendCommand(args []string, extra *model.CommandArgs) (bool, 
 		return false, err
 	}
 
-	p.trackSendIssue(extra.UserId, sourceCommand, false)
+	go p.trackSendIssue(extra.UserId, sourceCommand, false)
 
 	go p.sendRefreshEvent(extra.UserId, []string{OutListKey})
 	go p.sendRefreshEvent(receiver.Id, []string{InListKey})
@@ -182,7 +182,7 @@ func (p *Plugin) runAddCommand(args []string, extra *model.CommandArgs) (bool, e
 		return false, err
 	}
 
-	p.trackAddIssue(extra.UserId, sourceCommand, false)
+	go p.trackAddIssue(extra.UserId, sourceCommand, false)
 
 	go p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 

--- a/server/command.go
+++ b/server/command.go
@@ -155,8 +155,8 @@ func (p *Plugin) runSendCommand(args []string, extra *model.CommandArgs) (bool, 
 
 	p.trackSendIssue(extra.UserId, sourceCommand, false)
 
-	p.sendRefreshEvent(extra.UserId, []string{OutListKey})
-	p.sendRefreshEvent(receiver.Id, []string{InListKey})
+	go p.sendRefreshEvent(extra.UserId, []string{OutListKey})
+	go p.sendRefreshEvent(receiver.Id, []string{InListKey})
 
 	responseMessage := fmt.Sprintf("Todo sent to @%s.", userName)
 
@@ -184,7 +184,7 @@ func (p *Plugin) runAddCommand(args []string, extra *model.CommandArgs) (bool, e
 
 	p.trackAddIssue(extra.UserId, sourceCommand, false)
 
-	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
+	go p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Added Todo."
 
@@ -241,7 +241,7 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (bool, 
 	if err != nil {
 		return false, err
 	}
-	p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
+	go p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
 
 	responseMessage += issuesListToString(issues)
 	p.postCommandResponse(extra, responseMessage)
@@ -263,11 +263,11 @@ func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (bool, e
 
 	if foreignID != "" {
 		message := fmt.Sprintf("@%s popped a Todo you sent: %s", userName, issue.Message)
-		p.sendRefreshEvent(foreignID, []string{OutListKey})
+		go p.sendRefreshEvent(foreignID, []string{OutListKey})
 		p.PostBotDM(foreignID, message)
 	}
 
-	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
+	go p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Removed top Todo."
 

--- a/server/command.go
+++ b/server/command.go
@@ -146,8 +146,8 @@ func (p *Plugin) runSendCommand(args []string, extra *model.CommandArgs) (bool, 
 		return false, err
 	}
 
-	p.sendRefreshEvent(extra.UserId)
-	p.sendRefreshEvent(receiver.Id)
+	p.sendRefreshEvent(extra.UserId, []string{OutListKey})
+	p.sendRefreshEvent(receiver.Id, []string{InListKey})
 
 	responseMessage := fmt.Sprintf("Todo sent to @%s.", userName)
 
@@ -173,7 +173,7 @@ func (p *Plugin) runAddCommand(args []string, extra *model.CommandArgs) (bool, e
 		return false, err
 	}
 
-	p.sendRefreshEvent(extra.UserId)
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Added Todo."
 
@@ -230,7 +230,7 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (bool, 
 	if err != nil {
 		return false, err
 	}
-	p.sendRefreshEvent(extra.UserId)
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
 
 	responseMessage += issuesListToString(issues)
 	p.postCommandResponse(extra, responseMessage)
@@ -252,11 +252,11 @@ func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (bool, e
 
 	if foreignID != "" {
 		message := fmt.Sprintf("@%s popped a Todo you sent: %s", userName, issue.Message)
-		p.sendRefreshEvent(foreignID)
+		p.sendRefreshEvent(foreignID, []string{OutListKey})
 		p.PostBotDM(foreignID, message)
 	}
 
-	p.sendRefreshEvent(extra.UserId)
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Removed top Todo."
 

--- a/server/command.go
+++ b/server/command.go
@@ -85,7 +85,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	var handler func([]string, *model.CommandArgs) (bool, error)
 	if lengthOfArgs == 1 {
 		handler = p.runListCommand
-		go p.trackCommand(args.UserId, "")
+		p.trackCommand(args.UserId, "")
 	} else {
 		command := stringArgs[1]
 		if lengthOfArgs > 2 {
@@ -104,14 +104,14 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			handler = p.runSettingsCommand
 		default:
 			if command == "help" {
-				go p.trackCommand(args.UserId, command)
+				p.trackCommand(args.UserId, command)
 			} else {
-				go p.trackCommand(args.UserId, "not found")
+				p.trackCommand(args.UserId, "not found")
 			}
 			p.postCommandResponse(args, getHelp())
 			return &model.CommandResponse{}, nil
 		}
-		go p.trackCommand(args.UserId, command)
+		p.trackCommand(args.UserId, command)
 	}
 	isUserError, err := handler(restOfArgs, args)
 	if err != nil {
@@ -153,10 +153,10 @@ func (p *Plugin) runSendCommand(args []string, extra *model.CommandArgs) (bool, 
 		return false, err
 	}
 
-	go p.trackSendIssue(extra.UserId, sourceCommand, false)
+	p.trackSendIssue(extra.UserId, sourceCommand, false)
 
-	go p.sendRefreshEvent(extra.UserId, []string{OutListKey})
-	go p.sendRefreshEvent(receiver.Id, []string{InListKey})
+	p.sendRefreshEvent(extra.UserId, []string{OutListKey})
+	p.sendRefreshEvent(receiver.Id, []string{InListKey})
 
 	responseMessage := fmt.Sprintf("Todo sent to @%s.", userName)
 
@@ -182,9 +182,9 @@ func (p *Plugin) runAddCommand(args []string, extra *model.CommandArgs) (bool, e
 		return false, err
 	}
 
-	go p.trackAddIssue(extra.UserId, sourceCommand, false)
+	p.trackAddIssue(extra.UserId, sourceCommand, false)
 
-	go p.sendRefreshEvent(extra.UserId, []string{MyListKey})
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Added Todo."
 
@@ -242,7 +242,7 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (bool, 
 		return false, err
 	}
 
-	go p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
 
 	responseMessage += issuesListToString(issues)
 	p.postCommandResponse(extra, responseMessage)
@@ -263,13 +263,13 @@ func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (bool, e
 	userName := p.listManager.GetUserName(extra.UserId)
 
 	if foreignID != "" {
-		go p.sendRefreshEvent(foreignID, []string{OutListKey})
+		p.sendRefreshEvent(foreignID, []string{OutListKey})
 
 		message := fmt.Sprintf("@%s popped a Todo you sent: %s", userName, issue.Message)
 		p.PostBotDM(foreignID, message)
 	}
 
-	go p.sendRefreshEvent(extra.UserId, []string{MyListKey})
+	p.sendRefreshEvent(extra.UserId, []string{MyListKey})
 
 	responseMessage := "Removed top Todo."
 

--- a/server/command.go
+++ b/server/command.go
@@ -241,6 +241,7 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (bool, 
 	if err != nil {
 		return false, err
 	}
+
 	go p.sendRefreshEvent(extra.UserId, []string{MyListKey, OutListKey, InListKey})
 
 	responseMessage += issuesListToString(issues)
@@ -262,8 +263,9 @@ func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (bool, e
 	userName := p.listManager.GetUserName(extra.UserId)
 
 	if foreignID != "" {
-		message := fmt.Sprintf("@%s popped a Todo you sent: %s", userName, issue.Message)
 		go p.sendRefreshEvent(foreignID, []string{OutListKey})
+
+		message := fmt.Sprintf("@%s popped a Todo you sent: %s", userName, issue.Message)
 		p.PostBotDM(foreignID, message)
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -300,7 +300,6 @@ func (p *Plugin) handleComplete(w http.ResponseWriter, r *http.Request) {
 		p.handleErrorWithCode(w, http.StatusBadRequest, "Unable to decode JSON", err)
 		return
 	}
-	p.API.LogError("user ID: " + userID + "completeRequest.ID: " + completeRequest.ID)
 
 	issue, foreignID, listToUpdate, err := p.listManager.CompleteIssue(userID, completeRequest.ID)
 	if err != nil {
@@ -308,7 +307,7 @@ func (p *Plugin) handleComplete(w http.ResponseWriter, r *http.Request) {
 		p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to complete issue", err)
 		return
 	}
-	p.sendRefreshEvent(userID, []string{listToUpdate}) // p.sendRefereshEvent(userId, [listToUpdate])
+	p.sendRefreshEvent(userID, []string{listToUpdate})
 
 	userName := p.listManager.GetUserName(userID)
 	replyMessage := fmt.Sprintf("@%s completed a todo attached to this thread", userName)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -146,7 +146,7 @@ func (p *Plugin) handleTelemetry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if telemetryRequest.Event != "" {
-		go p.trackFrontend(userID, telemetryRequest.Event, telemetryRequest.Properties)
+		p.trackFrontend(userID, telemetryRequest.Event, telemetryRequest.Properties)
 	}
 }
 
@@ -182,9 +182,9 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		go p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
+		p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
 
-		go p.sendRefreshEvent(userID, []string{MyListKey})
+		p.sendRefreshEvent(userID, []string{MyListKey})
 
 		replyMessage := fmt.Sprintf("@%s attached a todo to this thread", senderName)
 		p.postReplyIfNeeded(addRequest.PostID, replyMessage, addRequest.Message)
@@ -207,9 +207,9 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		go p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
+		p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
 
-		go p.sendRefreshEvent(userID, []string{MyListKey})
+		p.sendRefreshEvent(userID, []string{MyListKey})
 
 		replyMessage := fmt.Sprintf("@%s attached a todo to this thread", senderName)
 		p.postReplyIfNeeded(addRequest.PostID, replyMessage, addRequest.Message)
@@ -223,10 +223,10 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.trackSendIssue(userID, sourceWebapp, addRequest.PostID != "")
+	p.trackSendIssue(userID, sourceWebapp, addRequest.PostID != "")
 
-	go p.sendRefreshEvent(userID, []string{OutListKey})
-	go p.sendRefreshEvent(receiver.Id, []string{InListKey})
+	p.sendRefreshEvent(userID, []string{OutListKey})
+	p.sendRefreshEvent(receiver.Id, []string{InListKey})
 
 	receiverMessage := fmt.Sprintf("You have received a new Todo from @%s", senderName)
 	p.PostBotCustomDM(receiver.Id, receiverMessage, addRequest.Message, issueID)
@@ -286,7 +286,7 @@ func (p *Plugin) handleList(w http.ResponseWriter, r *http.Request) {
 		lt := time.Unix(lastReminderAt/1000, 0).In(timezone)
 		if nt.Sub(lt).Hours() >= 1 && (nt.Day() != lt.Day() || nt.Month() != lt.Month() || nt.Year() != lt.Year()) {
 			p.PostBotDM(userID, "Daily Reminder:\n\n"+issuesListToString(issues))
-			go p.trackDailySummary(userID)
+			p.trackDailySummary(userID)
 			err = p.saveLastReminderTimeForUser(userID)
 			if err != nil {
 				p.API.LogError("Unable to save last reminder for user err=" + err.Error())
@@ -333,10 +333,10 @@ func (p *Plugin) handleAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.trackAcceptIssue(userID)
+	p.trackAcceptIssue(userID)
 
-	go p.sendRefreshEvent(userID, []string{MyListKey, InListKey})
-	go p.sendRefreshEvent(sender, []string{OutListKey})
+	p.sendRefreshEvent(userID, []string{MyListKey, InListKey})
+	p.sendRefreshEvent(sender, []string{OutListKey})
 
 	userName := p.listManager.GetUserName(userID)
 	message := fmt.Sprintf("@%s accepted a Todo you sent: %s", userName, todoMessage)
@@ -369,9 +369,9 @@ func (p *Plugin) handleComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.sendRefreshEvent(userID, []string{listToUpdate})
+	p.sendRefreshEvent(userID, []string{listToUpdate})
 
-	go p.trackCompleteIssue(userID)
+	p.trackCompleteIssue(userID)
 
 	userName := p.listManager.GetUserName(userID)
 	replyMessage := fmt.Sprintf("@%s completed a todo attached to this thread", userName)
@@ -381,7 +381,7 @@ func (p *Plugin) handleComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.sendRefreshEvent(foreignID, []string{OutListKey})
+	p.sendRefreshEvent(foreignID, []string{OutListKey})
 
 	message := fmt.Sprintf("@%s completed a Todo you sent: %s", userName, issue.Message)
 	p.PostBotDM(foreignID, message)
@@ -413,12 +413,12 @@ func (p *Plugin) handleRemove(w http.ResponseWriter, r *http.Request) {
 		p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to remove issue", err)
 		return
 	}
-	go p.sendRefreshEvent(userID, []string{listToUpdate})
+	p.sendRefreshEvent(userID, []string{listToUpdate})
 	if isSender {
-		go p.sendRefreshEvent(userID, []string{OutListKey})
+		p.sendRefreshEvent(userID, []string{OutListKey})
 	}
 
-	go p.trackRemoveIssue(userID)
+	p.trackRemoveIssue(userID)
 
 	userName := p.listManager.GetUserName(userID)
 	replyMessage := fmt.Sprintf("@%s removed a todo attached to this thread", userName)
@@ -436,7 +436,7 @@ func (p *Plugin) handleRemove(w http.ResponseWriter, r *http.Request) {
 		list = OutListKey
 	}
 
-	go p.sendRefreshEvent(foreignID, []string{list})
+	p.sendRefreshEvent(foreignID, []string{list})
 
 	p.PostBotDM(foreignID, message)
 }
@@ -468,13 +468,13 @@ func (p *Plugin) handleBump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.trackBumpIssue(userID)
+	p.trackBumpIssue(userID)
 
 	if foreignUser == "" {
 		return
 	}
 
-	go p.sendRefreshEvent(foreignUser, []string{InListKey})
+	p.sendRefreshEvent(foreignUser, []string{InListKey})
 
 	userName := p.listManager.GetUserName(userID)
 	message := fmt.Sprintf("@%s bumped a Todo you received.", userName)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -146,7 +146,7 @@ func (p *Plugin) handleTelemetry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if telemetryRequest.Event != "" {
-		p.trackFrontend(userID, telemetryRequest.Event, telemetryRequest.Properties)
+		go p.trackFrontend(userID, telemetryRequest.Event, telemetryRequest.Properties)
 	}
 }
 
@@ -181,7 +181,7 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 			p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to add issue", err)
 			return
 		}
-		p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
+		go p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
 		replyMessage := fmt.Sprintf("@%s attached a todo to this thread", senderName)
 		p.postReplyIfNeeded(addRequest.PostID, replyMessage, addRequest.Message)
 		go p.sendRefreshEvent(userID, []string{MyListKey})
@@ -202,7 +202,7 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 			p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to add issue", err)
 			return
 		}
-		p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
+		go p.trackAddIssue(userID, sourceWebapp, addRequest.PostID != "")
 		replyMessage := fmt.Sprintf("@%s attached a todo to this thread", senderName)
 		p.postReplyIfNeeded(addRequest.PostID, replyMessage, addRequest.Message)
 		go p.sendRefreshEvent(userID, []string{MyListKey})
@@ -218,7 +218,7 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.trackSendIssue(userID, sourceWebapp, addRequest.PostID != "")
+	go p.trackSendIssue(userID, sourceWebapp, addRequest.PostID != "")
 
 	receiverMessage := fmt.Sprintf("You have received a new Todo from @%s", senderName)
 	go p.sendRefreshEvent(receiver.Id, []string{InListKey})
@@ -279,7 +279,7 @@ func (p *Plugin) handleList(w http.ResponseWriter, r *http.Request) {
 		lt := time.Unix(lastReminderAt/1000, 0).In(timezone)
 		if nt.Sub(lt).Hours() >= 1 && (nt.Day() != lt.Day() || nt.Month() != lt.Month() || nt.Year() != lt.Year()) {
 			p.PostBotDM(userID, "Daily Reminder:\n\n"+issuesListToString(issues))
-			p.trackDailySummary(userID)
+			go p.trackDailySummary(userID)
 			err = p.saveLastReminderTimeForUser(userID)
 			if err != nil {
 				p.API.LogError("Unable to save last reminder for user err=" + err.Error())
@@ -328,7 +328,7 @@ func (p *Plugin) handleAccept(w http.ResponseWriter, r *http.Request) {
 	}
 	go p.sendRefreshEvent(userID, []string{MyListKey, InListKey})
 
-	p.trackAcceptIssue(userID)
+	go p.trackAcceptIssue(userID)
 
 	userName := p.listManager.GetUserName(userID)
 
@@ -365,7 +365,7 @@ func (p *Plugin) handleComplete(w http.ResponseWriter, r *http.Request) {
 
 	go p.sendRefreshEvent(userID, []string{listToUpdate})
 
-	p.trackCompleteIssue(userID)
+	go p.trackCompleteIssue(userID)
 
 	userName := p.listManager.GetUserName(userID)
 	replyMessage := fmt.Sprintf("@%s completed a todo attached to this thread", userName)
@@ -411,7 +411,7 @@ func (p *Plugin) handleRemove(w http.ResponseWriter, r *http.Request) {
 		go p.sendRefreshEvent(userID, []string{OutListKey})
 	}
 
-	p.trackRemoveIssue(userID)
+	go p.trackRemoveIssue(userID)
 
 	userName := p.listManager.GetUserName(userID)
 	replyMessage := fmt.Sprintf("@%s removed a todo attached to this thread", userName)
@@ -460,7 +460,7 @@ func (p *Plugin) handleBump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.trackBumpIssue(userID)
+	go p.trackBumpIssue(userID)
 
 	if foreignUser == "" {
 		return

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -414,9 +414,6 @@ func (p *Plugin) handleRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.sendRefreshEvent(userID, []string{listToUpdate})
-	if isSender {
-		p.sendRefreshEvent(userID, []string{OutListKey})
-	}
 
 	p.trackRemoveIssue(userID)
 

--- a/webapp/src/actions.js
+++ b/webapp/src/actions.js
@@ -74,11 +74,6 @@ export const add = (message, sendTo, postID) => async (dispatch, getState) => {
         method: 'post',
         body: JSON.stringify({message, send_to: sendTo, post_id: postID}),
     }));
-
-    dispatch(list());
-    if (sendTo) {
-        dispatch(list(false, 'out'));
-    }
 };
 
 export const list = (reminder = false, listName = 'my') => async (dispatch, getState) => {
@@ -119,10 +114,6 @@ export const remove = (id) => async (dispatch, getState) => {
         method: 'post',
         body: JSON.stringify({id}),
     }));
-
-    dispatch(list(false, 'my'));
-    dispatch(list(false, 'in'));
-    dispatch(list(false, 'out'));
 };
 
 export const complete = (id) => async (dispatch, getState) => {
@@ -130,9 +121,6 @@ export const complete = (id) => async (dispatch, getState) => {
         method: 'post',
         body: JSON.stringify({id}),
     }));
-
-    dispatch(list(false, 'my'));
-    dispatch(list(false, 'in'));
 };
 
 export const accept = (id) => async (dispatch, getState) => {
@@ -140,9 +128,6 @@ export const accept = (id) => async (dispatch, getState) => {
         method: 'post',
         body: JSON.stringify({id}),
     }));
-
-    dispatch(list(false, 'in'));
-    dispatch(list(false, 'my'));
 };
 
 export const bump = (id) => async (dispatch, getState) => {
@@ -150,8 +135,6 @@ export const bump = (id) => async (dispatch, getState) => {
         method: 'post',
         body: JSON.stringify({id}),
     }));
-
-    dispatch(list(false, 'out'));
 };
 
 export function autocompleteUsers(username) {

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -31,11 +31,26 @@ export default class Plugin {
         store.dispatch(setShowRHSAction(() => store.dispatch(showRHSPlugin)));
         registry.registerChannelHeaderButtonAction(<ChannelHeaderButton/>, () => store.dispatch(toggleRHSPlugin), 'Todo', 'Open your list of Todo issues.');
 
-        const refresh = () => {
-            store.dispatch(list(false, 'my'));
-            store.dispatch(list(false, 'in'));
-            store.dispatch(list(false, 'out'));
+        const getFrontendListName = (backendListName) => {
+            let frontendListName = 'my';
+            switch (backendListName) {
+            case '':
+                frontendListName = 'my';
+                break;
+            case '_in':
+                frontendListName = 'in';
+                break;
+            case '_out':
+                frontendListName = 'out';
+                break;
+            default:
+                frontendListName = 'my';
+                break;
+            }
+            return frontendListName;
         };
+
+        const refresh = ({data: {lists}}) => lists.forEach((listName) => store.dispatch(list(false, getFrontendListName(listName))));
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_refresh`, refresh);
         registry.registerReconnectHandler(refresh);


### PR DESCRIPTION
**Summary**
This PR fixes the issue, where the list of TODO's is not updated in real time on multiple clients. In addition to that, the backend now has full control over refreshing the lists (in, out, my). Therefore it's no longer necessary to do refreshing on the frontend.

**Note:** It would be better, if this PR was merged after [PR-49](https://github.com/mattermost/mattermost-plugin-todo/pull/49), because that one fixes the messages and therefore also the updates.

**Ticket link**
Fixes [#34](https://github.com/mattermost/mattermost-plugin-todo/issues/34)
