### PR TITLE
Add missing space to /todo (add|pop) response

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -157,7 +157,7 @@ func (p *Plugin) runAddCommand(args []string, extra *model.CommandArgs) (*model.
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, responseMessage), false, nil
 	}
 
-	responseMessage += "Todo List:\n\n"
+	responseMessage += " Todo List:\n\n"
 	responseMessage += issuesListToString(issues)
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, responseMessage), false, nil
@@ -219,7 +219,7 @@ func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (*model.
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, responseMessage), false, nil
 	}
 
-	responseMessage += "Todo List:\n\n"
+	responseMessage += " Todo List:\n\n"
 	responseMessage += issuesListToString(issues)
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, responseMessage), false, nil


### PR DESCRIPTION
#### Summary
Add missing space to /todo (add|pop) response

- "Added Todo.Todo List:" -> "Added Todo. Todo List:"
- "Removed top Todo.Todo List:" -> "Removed top Todo. Todo List:"

#### Ticket Link
Discovered while working on #4 

