### PR TITLE
Move registerReducer call to the top of `initialize`

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -15,8 +15,8 @@ const activityTimeout = 60 * 60 * 1000; // 1 hour
 
 export default class Plugin {
     initialize(registry, store) {
-        registry.registerRootComponent(Root);
         registry.registerReducer(reducer);
+        registry.registerRootComponent(Root);
 
         registry.registerPostDropdownMenuAction(
             'Add Todo',


### PR DESCRIPTION
#### Summary

This PR initializes the reducer for the plugin properly to avoid issues with `deep_freeze`.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/59
https://mattermost.atlassian.net/browse/MM-24682