### PR TITLE
Added missing commands to autocomplete suggestion

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -45,7 +45,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Todo Bot",
 		Description:      "Interact with your Todo list.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: add, list, pop",
+		AutoCompleteDesc: "Available commands: add, list, pop, send, help",
 		AutoCompleteHint: "[command]",
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
 Added the following missing commands to the autocomplete suggestion on typing ```/todo```:
 1. ```send```
 1. ```help```

#### Screenshots

Before:
![todo-before](https://user-images.githubusercontent.com/32198670/81482384-3efe9000-9254-11ea-9ab9-762a1742b8e5.png)
After:
![todo-after](https://user-images.githubusercontent.com/32198670/81482393-4c1b7f00-9254-11ea-88e2-b2610533a58f.png)


<!--
A description of what this pull request does.
-->

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/64

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

