### PR TITLE
Handle database replication delay when adding todos

### DIFF
--- a/server/list.go
+++ b/server/list.go
@@ -58,21 +58,21 @@ func NewListManager(api plugin.API) ListManager {
 	}
 }
 
-func (l *listManager) AddIssue(userID, message, postID string) error {
+func (l *listManager) AddIssue(userID, message, postID string) (*Issue, error) {
 	issue := newIssue(message, postID)
 
 	if err := l.store.AddIssue(issue); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := l.store.AddReference(userID, issue.ID, MyListKey, "", ""); err != nil {
 		if rollbackError := l.store.RemoveIssue(issue.ID); rollbackError != nil {
 			l.api.LogError("cannot rollback issue after add error, Err=", err.Error())
 		}
-		return err
+		return nil, err
 	}
 
-	return nil
+	return issue, nil
 }
 
 func (l *listManager) SendIssue(senderID, receiverID, message, postID string) (string, error) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -21,7 +21,7 @@ const (
 // ListManager represents the logic on the lists
 type ListManager interface {
 	// AddIssue adds a todo to userID's myList with the message
-	AddIssue(userID, message, postID string) error
+	AddIssue(userID, message, postID string) (*Issue, error)
 	// SendIssue sends the todo with the message from senderID to receiverID and returns the receiver's issueID
 	SendIssue(senderID, receiverID, message, postID string) (string, error)
 	// GetIssueList gets the todos on listID for userID
@@ -122,7 +122,7 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 	senderName := p.listManager.GetUserName(userID)
 
 	if addRequest.SendTo == "" {
-		err = p.listManager.AddIssue(userID, addRequest.Message, addRequest.PostID)
+		_, err = p.listManager.AddIssue(userID, addRequest.Message, addRequest.PostID)
 		if err != nil {
 			p.API.LogError("Unable to add issue err=" + err.Error())
 			p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to add issue", err)
@@ -141,7 +141,7 @@ func (p *Plugin) handleAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if receiver.Id == userID {
-		err = p.listManager.AddIssue(userID, addRequest.Message, addRequest.PostID)
+		_, err = p.listManager.AddIssue(userID, addRequest.Message, addRequest.PostID)
 		if err != nil {
 			p.API.LogError("Unable to add issue err=" + err.Error())
 			p.handleErrorWithCode(w, http.StatusInternalServerError, "Unable to add issue", err)


### PR DESCRIPTION
This change adds logic to ensure newly-added todos are in the
returned list. When the Mattermost server running the plugin has
database read replicas configured, it is possible that the plugin
would miss listing the new todo due to replication delay. This
plugin logic attempts to address the issue when it is detected.

I verified this issue and fix by using a dev server with a database
with read replicas configured.

When writing a fix, I went with something that felt like a good
trade-off on code complexity and speed. i.e. I avoided a simple
sleep, but also didn't want to drastically refactor code to fix
the issue in a slightly-better way. All that said, let me know what
you think.

Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/87

