### PR TITLE
Posting response when there are no Todos to pop instead of unkown error

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -216,6 +216,10 @@ func (p *Plugin) runListCommand(args []string, extra *model.CommandArgs) (bool, 
 func (p *Plugin) runPopCommand(args []string, extra *model.CommandArgs) (bool, error) {
 	issue, foreignID, err := p.listManager.PopIssue(extra.UserId)
 	if err != nil {
+		if err.Error() == "cannot find issue" {
+			p.postCommandResponse(extra, "There are no Todos to pop.")
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
This PR fixes issue 92 posting a response message when there are no Todos to pop instead of unkown error.
closes #92 


