### PR TITLE
Add ReleaseNotesURL

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,6 +4,7 @@
     "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.3.0",
     "version": "0.3.0",
     "min_server_version": "5.12.0",
     "server": {


### PR DESCRIPTION
#### Summary
Add ReleaseNotesURL for next Marketplace release. The version number as to be bumped when the next release is cut.
