### PR TITLE
Fix channel header icon highlight

### DIFF
--- a/webapp/src/components/channel_header_button/channel_header_button.scss
+++ b/webapp/src/components/channel_header_button/channel_header_button.scss
@@ -2,7 +2,7 @@
     &:active,
     &--active,
     &--active:hover {
-        fill: var(--button-bg) !important;
-        color: var(--button-bg) !important;
+        fill: var(--button-bg);
+        color: var(--button-bg);
     }
 }

--- a/webapp/src/components/channel_header_button/channel_header_button.scss
+++ b/webapp/src/components/channel_header_button/channel_header_button.scss
@@ -1,0 +1,8 @@
+.header-button {
+    &:active,
+    &--active,
+    &--active:hover {
+        fill: var(--button-bg) !important;
+        color: var(--button-bg) !important;
+    }
+}

--- a/webapp/src/components/channel_header_button/channel_header_button.scss
+++ b/webapp/src/components/channel_header_button/channel_header_button.scss
@@ -1,4 +1,4 @@
-.header-button {
+.todo-plugin-icon {
     &:active,
     &--active,
     &--active:hover {

--- a/webapp/src/components/channel_header_button/channel_header_button.tsx
+++ b/webapp/src/components/channel_header_button/channel_header_button.tsx
@@ -12,7 +12,7 @@ type Props = {
 export default function ChannelHeaderButton(props: Props) {
     let btnClass = 'icon fa fa-list';
     if (props.shouldHighlight) {
-        btnClass += ' header-button--active';
+        btnClass += ' todo-plugin-icon--active';
     }
 
     return (

--- a/webapp/src/components/channel_header_button/channel_header_button.tsx
+++ b/webapp/src/components/channel_header_button/channel_header_button.tsx
@@ -3,14 +3,19 @@
 
 import React from 'react';
 
+import './channel_header_button.scss';
+
 type Props = {
     shouldHighlight: boolean,
 };
 
 export default function ChannelHeaderButton(props: Props) {
+    let btnClass = 'icon fa fa-list';
+    if (props.shouldHighlight) {
+        btnClass += ' header-button--active';
+    }
+
     return (
-        <span className={props.shouldHighlight ? 'channel-header__icon--active' : ''} >
-            <i className='icon fa fa-list '/>
-        </span>
+        <i className={btnClass}/>
     );
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request will fix the channel header icon css when toggled in both scenarios (as an icon, part of drop-down list) by removing the background color for the icon.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-todo/issues/104

#### Screenshots
- As an icon in channel header
![Mattermost Theme](https://user-images.githubusercontent.com/1024128/90909154-f4221600-e407-11ea-8f16-d3f376f9e1a4.png) ![Windows Dark Theme](https://user-images.githubusercontent.com/1024128/90909147-f3897f80-e407-11ea-8f5b-9ba995e3a564.png)
- As an item in the drop down list
![Mattermost Theme](https://user-images.githubusercontent.com/1024128/90912058-84625a00-e40c-11ea-969e-e846e0933b0e.png) ![Windows Dark Theme](https://user-images.githubusercontent.com/1024128/90912061-85938700-e40c-11ea-9f39-dde772f43892.png)
