### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,8 +4,8 @@
     "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.3.0",
-    "version": "0.3.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
+    "version": "0.4.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -17,7 +17,8 @@ const manifestStr = `
   "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
   "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-  "version": "0.3.0",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
+  "version": "0.4.0",
   "min_server_version": "5.12.0",
   "server": {
     "executables": {
@@ -33,7 +34,16 @@ const manifestStr = `
   "settings_schema": {
     "header": "",
     "footer": "",
-    "settings": []
+    "settings": [
+      {
+        "key": "hide_team_sidebar",
+        "display_name": "Hide team sidebar buttons",
+        "type": "bool",
+        "help_text": "When true, the buttons in the team sidebar on the left toolbar will be hidden.",
+        "placeholder": "",
+        "default": null
+      }
+    ]
   }
 }
 `

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -7,7 +7,8 @@ const manifest = JSON.parse(`
     "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-    "version": "0.3.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
+    "version": "0.4.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {
@@ -23,7 +24,16 @@ const manifest = JSON.parse(`
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+            {
+                "key": "hide_team_sidebar",
+                "display_name": "Hide team sidebar buttons",
+                "type": "bool",
+                "help_text": "When true, the buttons in the team sidebar on the left toolbar will be hidden.",
+                "placeholder": "",
+                "default": null
+            }
+        ]
     }
 }
 `);


### PR DESCRIPTION
#### Summary
Bump version to v0.4.0

Proposal to bump Minor Version to prep for release with the following Release Notes:

#### Enhancements
* bfa5742 Add telemetry to Todo (#101)
* c865928 Add new plugin setting to toggle button visibility in team sidebar (#114)
* 1905ad5 Change channel header button to toggle RHS (#106)
* bb127b1 GH-88 Add settings command to toggle daily reminders (#90)
* 0e146a1 Mm 91 add active status to header icon (#96)
#### Fixes
* b2a69b7 Fix channel header icon highlight (#115)
* 6cce8b3 Fix plugin visuals to handle different themes (#116)
* ccfcd25 Improvement on texts and error behaviours on /todo settings (#110)
* 76cd654 Render correctly linebreaks (#108)
* ba724ab Make internal links to open in the same window, instead of reloading the page (#107)
* ff178b2 Handle database replication delay when adding todos (#93)
* ffa4359 Posting response when there are no Todos to pop instead of unk error (#105)
#### Other
* 920b07e Sync webapp/.gitignore with starter template (#113)
* cd547b1 Sync with starter template (#103)
* f84af9b Add ReleaseNotesURL (#111)
* 203547a Bump elliptic from 6.5.2 to 6.5.3 in /webapp (#112)
* bda3342 Bump lodash from 4.17.15 to 4.17.19 in /webapp (#98)

#### Ticket Link
None