### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,15 +4,16 @@
     "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
-    "version": "0.4.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.5.0",
+    "version": "0.5.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
             "windows-amd64": "server/dist/plugin-windows-amd64.exe"
-        }
+        },
+        "executable": ""
     },
     "webapp": {
         "bundle_path": "webapp/dist/main.js"
@@ -20,11 +21,15 @@
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": [{
-            "key": "hide_team_sidebar",
-            "display_name": "Hide team sidebar buttons:",
-            "type": "bool",
-            "help_text": "When true, the buttons in the team sidebar on the left toolbar will be hidden."
-        }]
+        "settings": [
+            {
+                "key": "hide_team_sidebar",
+                "display_name": "Hide team sidebar buttons:",
+                "type": "bool",
+                "help_text": "When true, the buttons in the team sidebar on the left toolbar will be hidden.",
+                "placeholder": "",
+                "default": null
+            }
+        ]
     }
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -17,8 +17,8 @@ const manifestStr = `
   "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
   "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
-  "version": "0.4.0",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.5.0",
+  "version": "0.5.0",
   "min_server_version": "5.12.0",
   "server": {
     "executables": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -7,8 +7,8 @@ const manifest = JSON.parse(`
     "description": "This plugin makes it easy to keep track of Todo issues and get daily reminders.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-todo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-todo/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.4.0",
-    "version": "0.4.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-todo/releases/tag/v0.5.0",
+    "version": "0.5.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Version bump to 0.5.0

Features:
d84f619 [GH-82] Add a user preference to disallow incoming Todos (#136)
46c4ee8 [GH-21] Add support markdown preview in add todo modal (#137)

Fixes
23fe723 Improve autocomplete component (#127)
cda3350 [GH-34] Fix list realtime (#50)
f6d9a24 Move the tracking for commands to only send the input command if it is one of the available (#119)

Others
653d9e4 go mod tidy (#141)
1bca666 make apply (#138)
a7665f3 Update plugin.json (#135)
72d5011 Bump ini from 1.3.5 to 1.3.8 in /webapp (#129)


#### Ticket Link
Fix https://github.com/mattermost/mattermost-plugin-todo/issues/128
