### PR TITLE
[MM-161] Disable the "goconst" linter for plugin.go file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,9 @@ issues:
     - path: server/configuration.go
       linters:
         - unused
+    - path: server/plugin.go
+      linters:
+        - goconst
     - path: _test\.go
       linters:
         - bodyclose


### PR DESCRIPTION
#### Summary
- Disable the "goconst" linter for the plugin.go file.
- The linter was giving some unnecessary lint errors.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-plugin-todo/pull/241#issuecomment-1904301497


