### PR TITLE
Fix issue of button not disabled while adding todo without title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,8 +37,7 @@
         "linux/dist/**": true,
     },
     "editor.codeActionsOnSave": {
-        // "source.organizeImports": true,
-        "source.fixAll.eslint": true,
+        "source.fixAll.eslint": "explicit"
     },
     "[typescriptreact]": {
         "editor.codeActionsOnSave": {

--- a/webapp/src/components/add_issue/add_issue.jsx
+++ b/webapp/src/components/add_issue/add_issue.jsx
@@ -143,7 +143,7 @@ export default class AddIssue extends React.PureComponent {
                                 <React.Fragment>
                                     <TextareaAutosize
                                         style={style.textareaResizeMessage}
-                                        placeholder='Enter a title *'
+                                        placeholder='Enter a title'
                                         autoFocus={true}
                                         onKeyDown={(e) => this.onKeyDown(e)}
                                         value={message}


### PR DESCRIPTION
#### Summary
- Fix issue of button not disabled while adding todo without title
- Added disabled prop in the button

#### Screenshot
![image](https://github.com/mattermost/mattermost-plugin-todo/assets/100013900/a43141a4-72b1-4e28-be0e-07cfcaea6539)


#### Ticket Link
Fixes #216 

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
