### PR TITLE
Better padding and a visual separator between todo's

### DIFF
--- a/webapp/src/components/sidebar_right/_todo-item.scss
+++ b/webapp/src/components/sidebar_right/_todo-item.scss
@@ -1,7 +1,8 @@
 .todo-item {
     transition: all 0.15s ease;
     cursor: pointer;
-    padding: 8px 16px;
+    padding: 16px 16px 8px;
+    border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.28);
 
     &.todo-item--hidden {
         height: 0;

--- a/webapp/src/components/sidebar_right/sidebar_right.scss
+++ b/webapp/src/components/sidebar_right/sidebar_right.scss
@@ -120,7 +120,7 @@
             margin-right: 8px;
         }
 
-        .todo-item__checkbox  {
+        .todo-item__checkbox {
             margin-right: 8px;
         }
     }


### PR DESCRIPTION
Add more padding and a separator between todo's

When looking through a list of more than a couple items of Todo's the list is too crowded.
This is especially true for the `Sent Todo's` list, which does not have a checkbox as a visual indicator that the the next todo is started.
This PR addresses the cramped list with more padding and a bottom border separator.

![image](https://github.com/user-attachments/assets/eb3a782a-8618-4d45-a0ea-71a9028cbf54)
